### PR TITLE
Add NO_GRAINSIZE_COMPUTE to remove grainsize computation until Tapir …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,13 @@ if (NOT ENABLE_VALIDATION)
     add_definitions("-DNO_VALIDATE")
 endif()
 
+set(ENABLE_GRAINSIZE_COMPUTATION "OFF"
+  CACHE BOOL "Allow pragma grainsize expression. Tapir toolchain does not currently allow this, grainsize must be integral constant."
+  )
+if (NOT ENABLE_GRAINSIZE_COMPUTATION)
+  add_definitions("-DNO_GRAINSIZE_COMPUTE")
+endif()
+
 function(add_exe filename)
     string(REGEX REPLACE "\\.[^.]*$" "" name ${filename})
     add_executable(${name} ${filename})

--- a/global_stream.c
+++ b/global_stream.c
@@ -96,7 +96,9 @@ void
 global_stream_add_cilk_for(global_stream_data * data)
 {
     long block_sz = data->n / NODELETS();
+#ifndef NO_GRAINSIZE_COMPUTE
     #pragma cilk grainsize = data->n / data->num_threads
+#endif
     cilk_for (long i = 0; i < data->n; ++i) {
         INDEX(data->c, block_sz, i) = INDEX(data->a, block_sz, i) + INDEX(data->b, block_sz, i);
     }

--- a/global_stream_1d.c
+++ b/global_stream_1d.c
@@ -92,7 +92,9 @@ global_stream_add_serial(global_stream_data * data)
 void
 global_stream_add_cilk_for(global_stream_data * data)
 {
+#ifndef NO_GRAINSIZE_COMPUTE
     #pragma cilk grainsize = data->n / data->num_threads
+#endif
     cilk_for (long i = 0; i < data->n; ++i) {
         data->c[i] = data->a[i] + data->b[i];
     }

--- a/global_stream_cxx.cc
+++ b/global_stream_cxx.cc
@@ -69,7 +69,9 @@ struct global_stream : public benchmark, public repl_new
     void
     add_cilk_for()
     {
+#ifndef NO_GRAINSIZE_COMPUTE
         #pragma cilk grainsize = n / num_threads
+#endif
         cilk_for (long i = 0; i < n; ++i) {
             c[i] = a[i] + b[i];
         }

--- a/local_stream.c
+++ b/local_stream.c
@@ -54,7 +54,9 @@ local_stream_add_serial(local_stream_data * data)
 void
 local_stream_add_cilk_for(local_stream_data * data)
 {
+#ifndef NO_GRAINSIZE_COMPUTE
     #pragma cilk grainsize = data->n / data->num_threads
+#endif
     cilk_for (long i = 0; i < data->n; ++i) {
         data->c[i] = data->a[i] + data->b[i];
     }

--- a/local_stream_cxx.cc
+++ b/local_stream_cxx.cc
@@ -52,7 +52,9 @@ struct local_stream {
     void
     add_cilk_for()
     {
+#ifndef NO_GRAINSIZE_COMPUTE
         #pragma cilk grainsize = n / num_threads
+#endif
         cilk_for (long i = 0; i < n; ++i) {
             c[i] = a[i] + b[i];
         }


### PR DESCRIPTION
…toolchain supports it